### PR TITLE
🩹[Patch]: Initial version of `Terraform-Init`

### DIFF
--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v5
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
       - name: Action-Test
         uses: ./
         with:

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Action-Test
         uses: ./
         with:
-          Subject: PSModule
+          WorkingDirectory: tests/Basic

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -24,6 +24,8 @@ jobs:
       # Need to check out as part of the test, as its a local action
       - name: Checkout repo
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/Auto-Release.yml
+++ b/.github/workflows/Auto-Release.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Auto-Release
         uses: PSModule/Auto-Release@v1

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Lint code base
         uses: super-linter/super-linter@latest

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Minimal example (uses defaults):
 ```yaml
 name: Terraform Init
 on:
-	workflow_dispatch:
-	push:
-		branches: [ main ]
+  workflow_dispatch:
+  push:
+    branches: [ main ]
 
 jobs:
 init:

--- a/README.md
+++ b/README.md
@@ -1,17 +1,82 @@
-# Template-Action
+# Terraform Init GitHub Action
 
-A template repository for GitHub Actions
+This action runs `terraform init` in a specified working directory as part of your IaC pipeline. It wraps a reusable PowerShell-based composite action that can optionally install/update the required supporting PowerShell module version, control prerelease usage, toggle locking behavior, and provide debug/verbose output for easier troubleshooting.
 
-## Usage
+## Features
 
-### Inputs
+- Executes `terraform init` in a chosen working directory (`WorkingDirectory` input; defaults to the repository root).
+- Optional state lock control via the `Lock` input.
+- Supports explicit module `Version` and allowing prereleases with `Prerelease`.
+- Adjustable verbosity: `Debug` and `Verbose` flags.
+- Pure composite action (no container) for fast startup.
 
-### Secrets
+## Inputs
 
-### Outputs
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `Lock` | No | `false` | Whether to lock the state file when running `terraform init`. Accepts `true` or `false`. |
+| `Debug` | No | `false` | Enable debug output (adds diagnostic logging). |
+| `Verbose` | No | `false` | Enable verbose output for more detailed operational logs. |
+| `Version` | No | (none) | Exact version of the GitHub PowerShell module to install/use. If omitted, the module's default resolution logic applies. |
+| `Prerelease` | No | `false` | Allow prerelease versions when resolving the module, if available. |
+| `WorkingDirectory` | No | `${{ github.workspace }}` | Directory from which `terraform init` will be executed. |
 
-### Example
+## Outputs
+
+This action does not currently set any explicit outputs.
+
+## Secrets
+
+No secrets are required. Provide any Terraform backend authentication separately (e.g., through environment variables, OpenID Connect, or other mechanism) before invoking this action.
+
+## Example Usage
+
+Minimal example (uses defaults):
 
 ```yaml
-Example here
+name: Terraform Init
+on:
+	workflow_dispatch:
+	push:
+		branches: [ main ]
+
+jobs:
+	init:
+		runs-on: ubuntu-latest
+		steps:
+			- name: Checkout
+				uses: actions/checkout@v4
+
+			- name: Set up Terraform
+				uses: hashicorp/setup-terraform@v3
+				with:
+					terraform_version: 1.9.2
+
+			- name: Terraform Init
+				uses: TFActions/Terraform-Init@v1
+				with:
+					WorkingDirectory: ./infra
 ```
+
+With optional flags:
+
+```yaml
+- name: Terraform Init (Verbose + Lock + Specific Module Version)
+	uses: TFActions/Terraform-Init@v1
+	with:
+		WorkingDirectory: ./infra
+		Lock: true
+		Verbose: true
+		Debug: false
+		Version: 1.2.3
+		Prerelease: false
+```
+
+## Contributing
+
+Issues and pull requests are welcome. Please open an issue describing enhancements or problems before large changes.
+
+## License
+
+Licensed under the terms of the `LICENSE` file in this repository.
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This action runs `terraform init` in a specified working directory as part of your IaC pipeline. It wraps a reusable PowerShell-based composite action that can optionally install/update the required supporting PowerShell module version, control prerelease usage, toggle locking behavior, and provide debug/verbose output for easier troubleshooting.
 
+## Prerequisites
+
+You must have the Terraform CLI available in the runner environment before using this action. The recommended (and tested) approach is to use the official HashiCorp setup action immediately before this action:
+See the [Example Usage](#example-usage) section below for the required setup snippet.
+
 ## Features
 
 - Executes `terraform init` in a chosen working directory (`WorkingDirectory` input; defaults to the repository root).
@@ -41,35 +46,21 @@ on:
 		branches: [ main ]
 
 jobs:
-	init:
-		runs-on: ubuntu-latest
-		steps:
-			- name: Checkout
-				uses: actions/checkout@v4
+init:
+  runs-on: ubuntu-latest
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
 
-			- name: Set up Terraform
-				uses: hashicorp/setup-terraform@v3
-				with:
-					terraform_version: 1.9.2
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: 1.9.2
 
-			- name: Terraform Init
-				uses: TFActions/Terraform-Init@v1
-				with:
-					WorkingDirectory: ./infra
-```
-
-With optional flags:
-
-```yaml
-- name: Terraform Init (Verbose + Lock + Specific Module Version)
-	uses: TFActions/Terraform-Init@v1
-	with:
-		WorkingDirectory: ./infra
-		Lock: true
-		Verbose: true
-		Debug: false
-		Version: 1.2.3
-		Prerelease: false
+    - name: Terraform Init
+      uses: TFActions/Terraform-Init@v1
+      with:
+        WorkingDirectory: ./infra
 ```
 
 ## Contributing

--- a/action.yml
+++ b/action.yml
@@ -1,15 +1,15 @@
-name: Template-Action
-description: A template action for GitHub Actions using PowerShell
-author: PSModule
+name: Terraform-Init
+description: A GitHub Action to run 'terraform init' in a specified directory.
+author: TFActions
 branding:
   icon: upload-cloud
   color: white
 
 inputs:
-  Subject:
-    description: The subject to greet
+  Lock:
+    description: Whether to lock the state file when running 'terraform init'. Accepts 'true' or 'false'.
     required: false
-    default: World
+    default: 'false'
   Debug:
     description: Enable debug output.
     required: false
@@ -36,7 +36,7 @@ runs:
     - name: Template-Action
       uses: PSModule/GitHub-Script@v1
       env:
-        PSMOUDLE_TEMPLATE_ACTION_INPUT_Subject: ${{ inputs.Subject }}
+        PSMODULE_TEMPLATE_ACTION_INPUT_Lock: ${{ inputs.Lock }}
       with:
         Name: Template-Action
         Debug: ${{ inputs.Debug }}

--- a/action.yml
+++ b/action.yml
@@ -33,12 +33,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Template-Action
+    - name: Terraform-Init
       uses: PSModule/GitHub-Script@v1
       env:
         PSMODULE_TEMPLATE_ACTION_INPUT_Lock: ${{ inputs.Lock }}
       with:
-        Name: Template-Action
+        Name: Terraform-Init
         Debug: ${{ inputs.Debug }}
         Prerelease: ${{ inputs.Prerelease }}
         Verbose: ${{ inputs.Verbose }}

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -6,20 +6,9 @@ param(
     [string] $Lock = $env:PSMODULE_TEMPLATE_ACTION_INPUT_Lock ?? 'false'
 )
 
-begin {
-    $scriptName = $MyInvocation.MyCommand.Name
-    Write-Debug "[$scriptName] - Start"
-}
-
-process {
-    LogGroup 'Terraform Init' {
-        terraform init -lock="$Lock"
-        if ($LASTEXITCODE -ne 0) {
-            exit $LASTEXITCODE
-        }
+LogGroup 'Terraform Init' {
+    terraform init -lock="$Lock"
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
     }
-}
-
-end {
-    Write-Debug "[$scriptName] - End"
 }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -3,7 +3,7 @@
 [CmdletBinding()]
 param(
     [Parameter()]
-    [string] $Subject = $env:PSMOUDLE_TEMPLATE_ACTION_INPUT_Subject
+    [string] $Lock = $env:PSMODULE_TEMPLATE_ACTION_INPUT_Lock ?? 'false'
 )
 
 begin {
@@ -12,10 +12,11 @@ begin {
 }
 
 process {
-    try {
-        Write-Output "Hello, $Subject!"
-    } catch {
-        throw $_
+    LogGroup 'Terraform Init' {
+        terraform init -lock=$Lock
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
     }
 }
 

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -5,7 +5,7 @@ Write-Debug "[$scriptName] - Start"
 
 $Lock = $env:PSMODULE_TEMPLATE_ACTION_INPUT_Lock ?? 'false'
 
-LogGroup 'Terraform Init' {
+LogGroup 'terraform init' {
     terraform init -lock="$Lock"
     if ($LASTEXITCODE -ne 0) {
         exit $LASTEXITCODE

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -1,10 +1,9 @@
 #Requires -Modules GitHub
 
-[CmdletBinding()]
-param(
-    [Parameter()]
-    [string] $Lock = $env:PSMODULE_TEMPLATE_ACTION_INPUT_Lock ?? 'false'
-)
+$scriptName = $MyInvocation.MyCommand.Name
+Write-Debug "[$scriptName] - Start"
+
+$Lock = $env:PSMODULE_TEMPLATE_ACTION_INPUT_Lock ?? 'false'
 
 LogGroup 'Terraform Init' {
     terraform init -lock="$Lock"
@@ -12,3 +11,5 @@ LogGroup 'Terraform Init' {
         exit $LASTEXITCODE
     }
 }
+
+Write-Debug "[$scriptName] - End"

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -13,7 +13,7 @@ begin {
 
 process {
     LogGroup 'Terraform Init' {
-        terraform init -lock=$Lock
+        terraform init -lock="$Lock"
         if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
         }

--- a/tests/Basic/main.tf
+++ b/tests/Basic/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    local = {
+      source = "hashicorp/local"
+    }
+  }
+}
+
+resource "local_file" "example" {
+  content  = "Hello, Terraform!"
+  filename = "${path.module}/hello.txt"
+}


### PR DESCRIPTION
This pull request refactors the repository from a generic GitHub Action template to a specialized "Terraform Init" GitHub Action. The changes focus on updating the action's identity, documentation, configuration, and implementation to support running `terraform init` with flexible options, including state locking and verbosity controls.

**Action Identity & Documentation Updates:**

* Renamed the action from "Template-Action" to "Terraform-Init" in `action.yml` and updated the author field to `TFActions`. The description now clearly states the purpose of the action.
* Overhauled `README.md` to describe the new Terraform Init action, its features, inputs, usage examples, and contribution guidelines. The documentation now explains all available options and provides sample workflows.

**Configuration & Implementation Changes:**

* Replaced the `Subject` input with a `Lock` input in `action.yml`, allowing control over Terraform state file locking. Updated environment variable mapping and composite action configuration accordingly. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L1-R12) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L39-R39)
* Updated the workflow example in `.github/workflows/Action-Test.yml` to use the `WorkingDirectory` input, demonstrating the new action usage.
* Refactored `scripts/main.ps1` to use the new `Lock` input and execute `terraform init -lock=$Lock`, removing the previous greeting logic and error handling. [[1]](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L6-R6) [[2]](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L15-R19)

**Testing Setup:**

* Added a basic Terraform configuration in `tests/Basic/main.tf` to facilitate testing of the action.